### PR TITLE
fix: add type alias for result

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod error;
 
-pub use self::error::{Error, Result};
+pub use self::error::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated public API: Error remains re-exported at the crate root; Result is now provided as a crate-level type alias rather than via the error module.
  - This may require updating imports. Use the crate-level Result for return types instead of referencing it from the error module, aligning usage and simplifying type signatures across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->